### PR TITLE
Add basic profile page

### DIFF
--- a/src/routes/profile/index.lazy.jsx
+++ b/src/routes/profile/index.lazy.jsx
@@ -1,7 +1,9 @@
 import { createLazyFileRoute } from '@tanstack/react-router'
+/** @jsxImportSource @emotion/react */
 import { Header } from '../../components/Header';
 import { Footer } from '../../components/Footer'
-import { UnderMaintenance } from '../../components/UnderMaintenance';
+import { css } from '@emotion/react'
+import { ClosingJob } from '../../components/ClosingJob'
 
 export const Route = createLazyFileRoute('/profile/')({
   component: ProfilePage
@@ -11,10 +13,70 @@ function ProfilePage() {
   return (
     <main className='app-main'>
       <Header />
-      <div className="app-body">
-        <UnderMaintenance />
+      <div className="app-body" css={profileBody}>
+        <img className='profile__avatar' src='https://via.placeholder.com/96' alt='Avatar' />
+        <h2>Hunter Doe</h2>
+        <p>hunter@example.com</p>
+        <button className='button primary'>Editar perfil</button>
+
+        <section className='hunts'>
+          <h3>Caças ativas</h3>
+          <div className='hunts__list'>
+            <ClosingJob onClick={() => {}} />
+            <ClosingJob onClick={() => {}} />
+          </div>
+        </section>
+
+        <section className='hunts'>
+          <h3>Caças anteriores</h3>
+          <div className='hunts__list'>
+            <ClosingJob onClick={() => {}} />
+            <ClosingJob onClick={() => {}} />
+          </div>
+        </section>
       </div>
       <Footer active='profile' />
     </main>
   )
 }
+
+const profileBody = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+
+  .profile__avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  h2 {
+    font-size: 20px;
+  }
+
+  p {
+    font-size: 14px;
+    color: #777;
+  }
+
+  .hunts {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    h3 {
+      font-size: 16px;
+    }
+
+    .hunts__list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+  }
+`


### PR DESCRIPTION
## Summary
- replace UnderMaintenance with actual profile layout on profile page
- show active and previous hunts sections on profile

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6840842c59bc832db87d4d34a88e7d0c